### PR TITLE
Accept 0 as major versions too

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ runs:
     # VERIFY INPUTS: sem_ver is a valid Semantic Version
     - name: "VERIFY INPUTS: sem_ver '${{ inputs.sem_ver }}' is a valid Semantic Version"
       run: |
-        if ! [[ "$INPUT_SEM_VER" =~ ^[0-9]+(\.[0-9]+){2}(-[a-zA-Z0-9]+)?$ ]]; then
+        if ! [[ "$INPUT_SEM_VER" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
           echo "[ERROR] Input 'sem_ver', with value '$INPUT_SEM_VER', is NOT a valid Semantic Version."
           echo "[DEBUG] Action requires a Semantic Version in the format 'X.Y.Z' or 'X.Y.Z-dev'."
           echo "Exiting with error."

--- a/action.yml
+++ b/action.yml
@@ -24,8 +24,8 @@ runs:
     # VERIFY INPUTS: sem_ver is a valid Semantic Version
     - name: "VERIFY INPUTS: sem_ver '${{ inputs.sem_ver }}' is a valid Semantic Version"
       run: |
-        if ! [[ "${{ inputs.sem_ver }}" =~ ^[0-9]+(\.[0-9]+){2}(-[a-zA-Z0-9]+)?$ ]]; then
-          echo "[ERROR] Input 'sem_ver', with value '${{ inputs.sem_ver }}', is NOT a valid Semantic Version."
+        if ! [[ "$INPUT_SEM_VER" =~ ^[0-9]+(\.[0-9]+){2}(-[a-zA-Z0-9]+)?$ ]]; then
+          echo "[ERROR] Input 'sem_ver', with value '$INPUT_SEM_VER', is NOT a valid Semantic Version."
           echo "[DEBUG] Action requires a Semantic Version in the format 'X.Y.Z' or 'X.Y.Z-dev'."
           echo "Exiting with error."
           exit 1

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ runs:
     # VERIFY INPUTS: sem_ver is a valid Semantic Version
     - name: "VERIFY INPUTS: sem_ver '${{ inputs.sem_ver }}' is a valid Semantic Version"
       run: |
-        if ! [[ "${{ inputs.sem_ver }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
+        if ! [[ "${{ inputs.sem_ver }}" =~ ^[0-9]+(\.[0-9]+){2}(-[a-zA-Z0-9]+)?$ ]]; then
           echo "[ERROR] Input 'sem_ver', with value '${{ inputs.sem_ver }}', is NOT a valid Semantic Version."
           echo "[DEBUG] Action requires a Semantic Version in the format 'X.Y.Z' or 'X.Y.Z-dev'."
           echo "Exiting with error."


### PR DESCRIPTION
While trying to use this, realised some of our microservices has versions like `0.41.0` which the validation rule do not accept. Including a small change at the validation rule to support `0` as major versions too.