### PR TITLE
Release v1.1.2-dev1

### DIFF
--- a/.github/agents/plan.agent.md
+++ b/.github/agents/plan.agent.md
@@ -1,0 +1,27 @@
+---
+description: 'Architect and planner to create detailed implementation plans.'
+tools: ['web/fetch', 'read/problems', 'search/codebase', 'search/usages', 'todo', 'agent', 'github/github-mcp-server/get_issue', 'github/github-mcp-server/get_issue_comments', 'github/github-mcp-server/list_issues']
+handoffs:
+- label: Start TDD Implementation
+    agent: tdd
+    prompt: Now implement the plan outlined above using TDD principles.
+    send: true
+- label: Start Implementation
+  agent: agent
+  prompt: 'Start (vanilla) implementation'
+  send: true
+- label: Open in Editor
+  agent: agent
+  prompt: '#createFile the plan as is into an untitled file (`untitled:plan-${camelCaseName}.prompt.md` without frontmatter) for further refinement.'
+  send: true
+  showContinueOn: false
+---
+# Planning Agent
+
+You are an architect focused on creating detailed and comprehensive implementation plans for new features and bug fixes. Your goal is to break down complex requirements into clear, actionable tasks that can be easily understood and executed by developers.
+
+## Workflow
+
+1. Analyze and understand: Gather context from the codebase and any provided documentation to fully understand the requirements and constraints. Run #tool:agent tool, instructing the agent to work autonomously without pausing for user feedback.
+2. Structure the plan: Use the provided [implementation plan template](../../.github/plan-template.md) to structure the plan.
+3. Pause for review: Based on user feedback or questions, iterate and refine the plan as needed.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,7 @@
+# [Project Name] Guidelines
+
+* [Product Vision and Goals](../PRODUCT.md): Understand the high-level vision and objectives of the product to ensure alignment with business goals.
+* [System Architecture and Design Principles](../ARCHITECTURE.md): Overall system architecture, design patterns, and design principles that guide the development process.
+* [Contributing Guidelines](../CONTRIBUTING.md): Overview of the project's contributing guidelines and collaboration practices.
+
+Suggest to update these documents if you find any incomplete or conflicting information during your work.

--- a/.github/plan-template.md
+++ b/.github/plan-template.md
@@ -1,0 +1,17 @@
+---
+title: [Short descriptive title of the feature]
+version: [optional version number]
+date_created: [YYYY-MM-DD]
+last_updated: [YYYY-MM-DD]
+---
+# Implementation Plan: <feature>
+[Brief description of the requirements and goals of the feature]
+
+## Architecture and design
+Describe the high-level architecture and design considerations.
+
+## Tasks
+Break down the implementation into smaller, manageable tasks using a Markdown checklist format.
+
+## Open questions
+Outline 1-3 open questions or uncertainties that need to be clarified.

--- a/.github/prompts/plan-qna.prompt.md
+++ b/.github/prompts/plan-qna.prompt.md
@@ -1,0 +1,5 @@
+---
+agent: plan
+description: Create a detailed implementation plan.
+---
+Briefly analyze my feature request, then ask me 3 questions to clarify the requirements. Only then start the planning workflow.

--- a/.github/workflows/_signal_deploy.yml
+++ b/.github/workflows/_signal_deploy.yml
@@ -35,7 +35,7 @@ jobs:
       ENVIRONMENT_NAME: ${{ steps.set_environment_name.outputs.ENVIRONMENT_NAME }}
     steps:
       # Fetch 'main' and 'release' branches
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ env.MAIN_BR }}

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -24,23 +24,42 @@ jobs:
         run: |
           echo 'Current Sem Ver: ${{ matrix.test_data.action_inputs.sem_ver }}'
           echo 'Bump Operator: ${{ matrix.test_data.action_inputs.bump_operator }}'
-          echo 'Expected Sem Ver: ${{ matrix.test_data.expected_semver }}'
+          echo 'Expected Sem Ver: ${{ matrix.test_data.expected_semver || '' }}'
+          echo 'Should Fail: ${{ matrix.test_data.should_fail || false }}'
 
       # WHEN the Action runs, with valid input Sem Ver and Bump Operator
       - name: WHEN Action Runs, with valid input Sem Ver and Bump Operator
         id: run_action
+        # support test cases where we expect error to be thrown, by not failing job when this step fails
+        continue-on-error: true
         uses: boromir674/action-semver-bumper@dev
         with:
           sem_ver: ${{ matrix.test_data.action_inputs.sem_ver }}
           bump_operator: ${{ matrix.test_data.action_inputs.bump_operator }}
 
-      # THEN the Action should return the expected Sem Ver
-      - name: ASSERT Action returns the expected Sem Ver '${{ matrix.test_data.expected_semver }}'
+      # THEN assert either expected success output or expected failure
+      - name: ASSERT Test Case Outcome
         run: |
-          if [ "${{ steps.run_action.outputs.new_sem_ver }}" = "${{ matrix.test_data.expected_semver }}" ]; then
-            echo "Action Returned Value is AS expected :)"
+          if [ "${{ matrix.test_data.should_fail || false }}" = "true" ]; then
+            if [ "${{ steps.run_action.outcome }}" = "failure" ]; then
+              echo "Action failed as expected :)"
+            else
+              echo "Action was expected to fail, but it succeeded!"
+              echo [ASSERTION ERROR] "Outcome: ${{ steps.run_action.outcome }}"
+              exit 1
+            fi
           else
-            echo "Action Return Value is NOT as expected!"
-            echo [ASSERTION ERROR] "Actual: ${{ steps.run_action.outputs.new_sem_ver }} | Expected: ${{ matrix.test_data.expected_semver }}"
-            exit 1
+            if [ "${{ steps.run_action.outcome }}" != "success" ]; then
+              echo "Action was expected to succeed, but failed!"
+              echo [ASSERTION ERROR] "Outcome: ${{ steps.run_action.outcome }}"
+              exit 1
+            fi
+
+            if [ "${{ steps.run_action.outputs.new_sem_ver }}" = "${{ matrix.test_data.expected_semver }}" ]; then
+              echo "Action Returned Value is AS expected :)"
+            else
+              echo "Action Return Value is NOT as expected!"
+              echo [ASSERTION ERROR] "Actual: ${{ steps.run_action.outputs.new_sem_ver }} | Expected: ${{ matrix.test_data.expected_semver }}"
+              exit 1
+            fi
           fi

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -130,6 +130,126 @@ jobs:
                 "bump_operator": "major"
               },
               "expected_semver": "2.0.0"
+            },
+            {
+              "name": "TEST 5a: Zero Version Major Bump",
+              "action_inputs": {
+                "sem_ver": "0.0.0",
+                "bump_operator": "MAJOR"
+              },
+              "expected_semver": "1.0.0"
+            },
+            {
+              "name": "TEST 5b: Zero Version Minor Bump",
+              "action_inputs": {
+                "sem_ver": "0.0.0",
+                "bump_operator": "MINOR"
+              },
+              "expected_semver": "0.1.0"
+            },
+            {
+              "name": "TEST 5c: Zero Version Patch Bump",
+              "action_inputs": {
+                "sem_ver": "0.0.0",
+                "bump_operator": "PATCH"
+              },
+              "expected_semver": "0.0.1"
+            },
+            {
+              "name": "TEST 5d: Zero Version Dev Pre-release Bump",
+              "action_inputs": {
+                "sem_ver": "0.0.0",
+                "bump_operator": "DEV_PRERELEASE"
+              },
+              "expected_semver": "0.0.1-dev"
+            },
+            {
+              "name": "TEST 6a: Dev Counter starts at implicit zero",
+              "action_inputs": {
+                "sem_ver": "1.0.0-dev",
+                "bump_operator": "DEV_PRERELEASE"
+              },
+              "expected_semver": "1.0.0-dev1"
+            },
+            {
+              "name": "TEST 6b: Dev Counter starts at explicit zero",
+              "action_inputs": {
+                "sem_ver": "1.0.0-dev0",
+                "bump_operator": "DEV_PRERELEASE"
+              },
+              "expected_semver": "1.0.0-dev1"
+            },
+            {
+              "name": "TEST 6c: High Dev Counter increments",
+              "action_inputs": {
+                "sem_ver": "1.0.0-dev99",
+                "bump_operator": "DEV_PRERELEASE"
+              },
+              "expected_semver": "1.0.0-dev100"
+            },
+            {
+              "name": "TEST 7a: Mixed Case Operator 'Patch'",
+              "action_inputs": {
+                "sem_ver": "1.0.0",
+                "bump_operator": "Patch"
+              },
+              "expected_semver": "1.0.1"
+            },
+            {
+              "name": "TEST 7b: Random Case Operator 'pAtCh'",
+              "action_inputs": {
+                "sem_ver": "1.0.0",
+                "bump_operator": "pAtCh"
+              },
+              "expected_semver": "1.0.1"
+            },
+            {
+              "name": "TEST 8a: INVALID sem_ver missing patch",
+              "action_inputs": {
+                "sem_ver": "1.2",
+                "bump_operator": "PATCH"
+              },
+              "should_fail": true
+            },
+            {
+              "name": "TEST 8b: INVALID sem_ver non-numeric",
+              "action_inputs": {
+                "sem_ver": "a.b.c",
+                "bump_operator": "MINOR"
+              },
+              "should_fail": true
+            },
+            {
+              "name": "TEST 8c: INVALID sem_ver empty prerelease",
+              "action_inputs": {
+                "sem_ver": "1.2.3-",
+                "bump_operator": "PATCH"
+              },
+              "should_fail": true
+            },
+            {
+              "name": "TEST 9a: INVALID bump operator typo",
+              "action_inputs": {
+                "sem_ver": "1.2.3",
+                "bump_operator": "MAJR"
+              },
+              "should_fail": true
+            },
+            {
+              "name": "TEST 9b: INVALID bump operator empty",
+              "action_inputs": {
+                "sem_ver": "1.2.3",
+                "bump_operator": ""
+              },
+              "should_fail": true
+            },
+            {
+              "name": "TEST 9c: INVALID bump operator with whitespace",
+              "action_inputs": {
+                "sem_ver": "1.2.3",
+                "bump_operator": " PATCH"
+              },
+              "should_fail": true
             }
           ]
         }

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,6 +22,7 @@ Core runtime lives in `action.yml` using bash steps.
 ## CI/CD Design
 
 - Entry pipeline: `.github/workflows/cicd.yml`.
+- Test suite: matrix scenarios declared in `cicd.yml` and executed by reusable workflow `.github/workflows/_test.yml`.
 - Test execution is reusable: `.github/workflows/_test.yml`.
 - Test strategy: JSON matrix of GIVEN/WHEN/THEN cases.
 - Quality gate job aggregates upstream job outcomes.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,41 @@
+# Architecture
+
+## Overview
+
+This repository ships a **composite GitHub Action** that bumps a Semantic Version.
+Core runtime lives in `action.yml` using bash steps.
+
+## Runtime Flow
+
+1. Validate `sem_ver` format (`X.Y.Z` with optional prerelease suffix).
+2. Validate `bump_operator` against supported values.
+3. Normalize operator to uppercase (case-insensitive behavior).
+4. Apply bump logic:
+   - `MAJOR` -> `major+1`, reset `minor` and `patch`.
+   - `MINOR` -> `minor+1`, reset `patch`.
+   - `PATCH` -> `patch+1`.
+   - `DEV_PRERELEASE` ->
+     - if already `devN`, increment only dev counter;
+     - otherwise increment patch and append `-dev`.
+5. Publish `new_sem_ver` through `$GITHUB_OUTPUT`.
+
+## CI/CD Design
+
+- Entry pipeline: `.github/workflows/cicd.yml`.
+- Test execution is reusable: `.github/workflows/_test.yml`.
+- Test strategy: JSON matrix of GIVEN/WHEN/THEN cases.
+- Quality gate job aggregates upstream job outcomes.
+- Tag pushes trigger deploy signaling and then GitHub Release.
+
+## Deployment Signaling
+
+- `.github/workflows/_signal_deploy.yml` checks whether a tag belongs to `main` or `release`.
+- It emits:
+  - `AUTOMATED_DEPLOY` (boolean)
+  - `ENVIRONMENT_NAME` (`PROD_DEPLOYMENT` or `TEST_DEPLOYMENT`)
+
+## Architectural Intent
+
+- Keep logic deterministic and side-effect free.
+- Keep interface minimal: 2 inputs, 1 output.
+- Keep tests behavior-oriented and easy to extend.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 
+## 1.1.2-dev1 (2026-07-05)
+
+### Changes
+
+#### Test
+
+- Add **15 test cases**, including ones excercising unhappy paths
+
+
 ## 1.1.2-dev (2025-06-21)
 
 ### Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing
+
+Thanks for contributing to Semantic Version Bumper.
+
+This project follows a simple rule: **do one thing, and do it well**.
+Contributions should preserve this focus.
+
+## What to Contribute
+
+- Bug fixes in SemVer bumping behavior.
+- Test-case additions for real scenarios.
+- Docs improvements that clarify behavior and boundaries.
+- CI/CD improvements that increase reliability.
+
+## Scope Guardrails
+
+- In scope: deterministic version bumping from valid inputs.
+- Out of scope: parsing commit history, release policy engines, changelog generation.
+
+## Development Flow
+
+1. Fork and create a feature branch.
+2. Keep changes small and focused.
+3. Update docs when behavior changes.
+4. Add or adjust test cases in `.github/workflows/cicd.yml` matrix.
+5. Open a PR with clear before/after behavior.
+
+## Testing
+
+- The action is validated through matrix-based workflow tests in `.github/workflows/_test.yml`.
+- Each test defines `sem_ver`, `bump_operator`, and `expected_semver`.
+- PRs should preserve existing cases and add new ones for edge conditions.
+
+## Style
+
+- Prefer clarity over cleverness.
+- Keep bash logic explicit and deterministic.
+- Keep operator handling case-insensitive.
+- Keep docs aligned with `README.md` and `CHANGELOG.md`.
+
+## Release Notes
+
+If your PR changes behavior, include a short "why" and "impact" note.
+This helps keep release notes meaningful and user-centered.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,9 @@ Contributions should preserve this focus.
 
 ## Testing
 
+- Test suite in this project means: the CI matrix in `.github/workflows/cicd.yml` + the reusable runner in `.github/workflows/_test.yml`.
 - The action is validated through matrix-based workflow tests in `.github/workflows/_test.yml`.
-- Each test defines `sem_ver`, `bump_operator`, and `expected_semver`.
+- Each test defines `sem_ver`, `bump_operator`, and expected outcome (`expected_semver` or `should_fail`).
 - PRs should preserve existing cases and add new ones for edge conditions.
 
 ## Style

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -31,7 +31,7 @@ This action provides deterministic, automation-friendly SemVer bumping.
 - Pure-function mindset: same input, same output.
 - Single responsibility: no commit parsing, no release orchestration.
 - Low integration friction: drop-in composite action.
-- Tested Github Action 
+- Test suite backed: behavior is validated by CI matrix scenarios.
 
 ## Non-Goals
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,46 @@
+# Product
+
+## Semantic Version Bumper
+
+Semantic Version Bumper is a focused GitHub Action for one job:
+turn **(current version + bump operator)** into **new semantic version**.
+
+## Problem It Solves
+
+Teams need consistent version increments in CI/CD.
+Manual bumping is repetitive and error-prone.
+This action provides deterministic, automation-friendly SemVer bumping.
+
+## Target Users
+
+- Maintainers running release pipelines on GitHub Actions.
+- Teams that want explicit, auditable bump behavior.
+- Projects that need dev prerelease progression (`-dev`, `-dev1`, ...).
+
+## Product Behavior
+
+- Inputs: `sem_ver`, `bump_operator`.
+- Output: `new_sem_ver`.
+- Operators: `MAJOR`, `MINOR`, `PATCH`, `DEV_PRERELEASE` (case-insensitive).
+- Dev prerelease rule:
+  - stable -> patch+1 and `-dev`
+  - existing dev prerelease -> increment dev counter only
+
+## Product Principles
+
+- Pure-function mindset: same input, same output.
+- Single responsibility: no commit parsing, no release orchestration.
+- Low integration friction: drop-in composite action.
+- Tested Github Action 
+
+## Non-Goals
+
+- Deciding bump level from Conventional Commits.
+- Managing changelog strategy.
+- Acting as a full release manager.
+
+## Success Criteria
+
+- Predictable output across all supported bump operators.
+- Clear test coverage through CI matrix scenarios.
+- Documentation that makes behavior obvious to first-time users.

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Bump Semantic Version
         id: bump_version


### PR DESCRIPTION
- chore: configure agentic coding
- test: add 15 test cases, including testing unhappy paths
- chore: add Release v1.1.2-dev1 entry in Changelog
- ci: bump action/checkout to v5 from v4
